### PR TITLE
Update bayes-theorem.Rmd

### DIFF
--- a/bayes-theorem.Rmd
+++ b/bayes-theorem.Rmd
@@ -186,7 +186,7 @@ science <- tribble(
 
 Calculate the posterior probability for each value of `theta`,
 for the different cases of `x`:
-  ```{r}
+```{r}
 group_by(science, x) %>%
   mutate(marginal   = sum(likelihood * prior),
          posterior = likelihood * prior / marginal


### PR DESCRIPTION
I think that the extra spaces before the code block on line 189 prevented it from being processed by Rmarkdown and instead was just output as is. The results of this block aren't used which is why it didn't cause an error, but the processed result was different (now showing the "posterior probability" but rather only the code to generate it.

(I didn't try re-processing this file to make sure that removing the spaces works, but it "should" fix it.)