### PR TITLE
Update naive-bayes.Rmd

### DIFF
--- a/naive-bayes.Rmd
+++ b/naive-bayes.Rmd
@@ -90,7 +90,7 @@ For the distribution $p(x_1, \dots, x_K | y)$, we will use the multinomial distr
 $$
 p(x | y = j, \theta) = \mathrm{Multinomial}(x | \theta^{(j)}) .
 $$
-The parameter $\theta_j$ is length $K$ vector, such that $\sum_{k = 1}^K \theta_k^{(j)} = 1$.
+The parameter $\theta^{(j)}$ is length $K$ vector, such that $\sum_{k = 1}^K \theta_k^{(j)} = 1$.
 The superscript $(j)$ indicates that $\theta^{(j)}$ is specific to a particular class.
 Thus there are $\text{classes} \times \text{features} = J \times K$ parameters to estimate for this model.
 $$
@@ -142,7 +142,7 @@ These can be justified using as [conjugate prior distributions](https://en.wikip
 
 Now that we've estimated $\hat{p}(y | x)$ and $\hat{p}(y)$ we can predict the classes for both the papers where the author was observed, and those that it wasn't observed.
 
-Calculate the probability of each class, $p(y_{test} | x_{test}, \hat{theta})$, for all documents given the learned parameters $\theta$.
+Calculate the probability of each class, $p(y_{test} | x_{test}, \hat{\theta})$, for all documents given the learned parameters $\theta$.
 ```{r}
 pred_doc_author <- federalist$wordcounts %>%
   # keep only Hamilton, Madison, and undetermined


### PR DESCRIPTION
First, changed the reference to class parameter list `\theta_j` on line 93 to have the same form as later: `\theta^{(j)}`.

Second, changed line 145 to use `\hat{\theta}` rather than `\hat{theta}` (which was missing the backslash in tbe math expression for the symbol theta.